### PR TITLE
Refactor searchable select

### DIFF
--- a/src/selects/StatelessSearchableSelect.js
+++ b/src/selects/StatelessSearchableSelect.js
@@ -1,0 +1,191 @@
+import React, {PropTypes} from 'react'
+import styles from 'part:@sanity/components/selects/searchable-style'
+import {uniqueId} from 'lodash'
+import FaAngleDown from 'part:@sanity/base/angle-down-icon'
+import DefaultFormField from 'part:@sanity/components/formfields/default'
+import DefaultTextInput from 'part:@sanity/components/textinputs/default'
+import DefaultList from 'part:@sanity/components/lists/default'
+import Spinner from 'part:@sanity/components/loading/spinner'
+import enhanceWithClickOutside from 'react-click-outside'
+import CloseIcon from 'part:@sanity/base/close-icon'
+
+const noop = () => {}
+
+class StatelessSearchableSelect extends React.PureComponent {
+  static propTypes = {
+    label: PropTypes.string.isRequired,
+    description: PropTypes.string,
+    onChange: PropTypes.func,
+    value: PropTypes.any,
+    hasFocus: PropTypes.bool,
+
+    inputValue: PropTypes.string,
+    onInputChange: PropTypes.func,
+    onFocus: PropTypes.func,
+    onBlur: PropTypes.func,
+
+    onClear: PropTypes.func,
+    renderItem: PropTypes.func,
+    placeholder: PropTypes.string,
+
+    hasError: PropTypes.bool,
+    isLoading: PropTypes.bool,
+
+    isOpen: PropTypes.bool,
+    onOpen: PropTypes.func,
+    onClose: PropTypes.func,
+
+    items: PropTypes.array,
+
+    highlightIndex: PropTypes.number,
+    onHighlightIndexChange: PropTypes.func,
+
+    isInputSelected: PropTypes.bool
+  }
+
+  static defaultProps = {
+    onChange: noop,
+    onOpen: noop,
+    onClose: noop,
+    onInputChange: noop,
+    hasError: false,
+    hasFocus: false,
+    isLoading: false,
+    renderItem: item => item,
+    items: []
+  }
+
+  handleClickOutside = () => {
+    this.props.onClose()
+  }
+
+  handleInputFocus = event => {
+    this.props.onFocus(event)
+  }
+
+  handleInputBlur = event => {
+    this.props.onBlur(event)
+  }
+
+  handleSelect = item => {
+    this.props.onChange(item)
+  }
+
+  handleArrowClick = () => {
+    const {isOpen, onOpen, onClose} = this.props
+    if (isOpen) {
+      onClose()
+    } else {
+      onOpen()
+    }
+  }
+
+  handleInputChange = event => {
+    this.props.onInputChange(event.target.value)
+  }
+
+  handleKeyDown = event => {
+    const {items, highlightIndex, onHighlightIndexChange, isOpen, onOpen} = this.props
+    if (!items || items.length === 0) {
+      return
+    }
+    if (event.key == 'ArrowUp' && highlightIndex > -1) {
+      event.preventDefault()
+      onHighlightIndexChange(Math.max(highlightIndex - 1, -1))
+    }
+    if (event.key == 'ArrowDown' && highlightIndex < items.length - 1) {
+      event.preventDefault()
+
+      if (isOpen) {
+        onHighlightIndexChange(Math.min(highlightIndex + 1, items.length - 1))
+      } else {
+        onOpen()
+      }
+    }
+  }
+
+  handleKeyUp = event => {
+    const {items, onChange, highlightIndex} = this.props
+    if (event.key == 'Enter' && highlightIndex > -1) {
+      onChange(items[highlightIndex])
+    }
+  }
+
+  componentWillMount() {
+    this._inputId = uniqueId('SearchableSelect')
+  }
+
+  render() {
+    const {
+      label,
+      hasError,
+      onClear,
+      placeholder,
+      isLoading,
+      value,
+      description,
+      items,
+      renderItem,
+      hasFocus,
+      isOpen,
+      highlightIndex,
+      isInputSelected,
+      inputValue
+    } = this.props
+
+    return (
+      <DefaultFormField
+        className={`${styles.root} ${hasFocus && styles.focused} ${hasError && styles.error}`}
+        description={description}
+        labelHtmlFor={this._inputId}
+        label={label}
+      >
+        <div className={styles.selectContainer}>
+          <DefaultTextInput
+            className={styles.select}
+            id={this._inputId}
+            placeholder={placeholder}
+            onChange={this.handleInputChange}
+            onKeyDown={this.handleKeyDown}
+            onKeyUp={this.handleKeyUp}
+            onFocus={this.handleInputFocus}
+            onBlur={this.handleInputBlur}
+            value={inputValue || ''}
+            selected={isInputSelected}
+            hasFocus={hasFocus}
+          />
+          {
+            onClear && (
+              <button className={styles.clearButton} onClick={onClear}>
+                <CloseIcon color="inherit" />
+              </button>
+            )
+          }
+          {isLoading && <div className={styles.spinner}><Spinner /></div>}
+          {!isLoading && (
+            <div className={styles.icon} onClick={this.handleArrowClick}>
+              <FaAngleDown color="inherit" />
+            </div>
+          )}
+        </div>
+
+        <div className={`${isOpen ? styles.listContainer : styles.listContainerHidden}`}>
+          {
+            items.length == 0 && <p className={styles.noResultText}>No results</p>
+          }
+          <DefaultList
+            items={items}
+            scrollable
+            highlightedItem={(items && items[highlightIndex]) || value}
+            selectedItem={value}
+            onSelect={this.handleSelect}
+            renderItem={renderItem}
+          />
+        </div>
+
+      </DefaultFormField>
+    )
+  }
+}
+
+export default enhanceWithClickOutside(StatelessSearchableSelect)

--- a/src/selects/story.js
+++ b/src/selects/story.js
@@ -140,7 +140,7 @@ class SearchableTest extends React.Component {
       <SearchableSelect
         label="This is the label"
         placeholder="This is the placeholder"
-        onSearch={this.handleSearch}
+        onInputChange={this.handleSearch}
         onChange={this.handleChange}
         onFocus={this.handleFocus}
         onOpen={action('onOpen')}
@@ -206,7 +206,7 @@ storiesOf('Selects')
 .addWithInfo(
   'Searchable (selected value)',
   `
-    When provided with items, the component searches inside these when no onSearch is provided
+    When provided with items, the component searches inside these when no onInputChange is provided
   `,
   () => {
     const renderItem = function (item) {
@@ -214,9 +214,7 @@ storiesOf('Selects')
         <div>{item.title}</div>
       )
     }
-    const renderValue = function (item) {
-      return item.title
-    }
+    const valueToString = item => item.title
     return (
       <SearchableSelect
         label="This is the label"
@@ -226,7 +224,7 @@ storiesOf('Selects')
         onBlur={action('onBlur')}
         onOpen={action('onOpen')}
         value={items[5]}
-        renderValue={renderValue}
+        valueToString={valueToString}
         renderItem={renderItem}
         items={items}
       />
@@ -241,31 +239,39 @@ storiesOf('Selects')
 .addWithInfo(
   'Searchable (selected value, renderItem)',
   `
-    When provided with items, the component searches inside these when no onSearch is provided
+    When provided with items, the component searches inside these when no onInputChange is provided
   `,
   () => {
-    const renderItem = function (item) {
-      return (
-        <div>{item.title}</div>
-      )
+    class Example extends React.Component {
+      state = {
+        value: items[4],
+
+      }
+      render() {
+        const renderItem = function (item) {
+          return (
+            <div>{item.title}</div>
+          )
+        }
+
+        const valueToString = item => item.title
+        return (
+          <SearchableSelect
+            label="This is the label"
+            placeholder="This is the placeholder"
+            onChange={item => this.setState({value: item})}
+            onFocus={action('onFocus')}
+            onBlur={action('onBlur')}
+            onOpen={action('onOpen')}
+            value={this.state.value}
+            items={items}
+            renderItem={renderItem}
+            valueToString={valueToString}
+          />
+        )
+      }
     }
-    const renderValue = function (item) {
-      return item.title
-    }
-    return (
-      <SearchableSelect
-        label="This is the label"
-        placeholder="This is the placeholder"
-        onChange={action('onChange')}
-        onFocus={action('onFocus')}
-        onBlur={action('onBlur')}
-        onOpen={action('onOpen')}
-        value={items[5]}
-        items={items}
-        renderItem={renderItem}
-        renderValue={renderValue}
-      />
-    )
+    return <Example />
   },
   {
     propTables: [SearchableSelect],
@@ -276,7 +282,7 @@ storiesOf('Selects')
 .addWithInfo(
   'Searchable (with onClear)',
   `
-    When provided with items, the component searches inside these when no onSearch is provided
+    When provided with items, the component searches inside these when no onInputChange is provided
   `,
   () => {
     const renderItem = function (item) {
@@ -284,9 +290,8 @@ storiesOf('Selects')
         <div>{item.title}</div>
       )
     }
-    const renderValue = function (item) {
-      return item.title
-    }
+    const valueToString = value => value.title
+
     return (
       <SearchableSelect
         label="This is the label"
@@ -299,7 +304,7 @@ storiesOf('Selects')
         value={items[5]}
         items={items}
         renderItem={renderItem}
-        renderValue={renderValue}
+        valueToString={valueToString}
       />
     )
   },
@@ -327,7 +332,7 @@ storiesOf('Selects')
       <SearchableSelect
         label="This is the label"
         placeholder="This is the placeholder"
-        onSearch={action('onSearch')}
+        onInputChange={action('onInputChange')}
         onChange={action('onChange')}
         onFocus={action('onFocus')}
         onOpen={action('onOpen')}
@@ -502,7 +507,7 @@ storiesOf('Selects')
 .addWithInfo(
   'Searchable example',
   `
-    When an onSearch is provided. Populate the items, and remember to set _loading prop_ when waiting for server.
+    When an onInputChange is provided. Populate the items, and remember to set _loading prop_ when waiting for server.
   `,
   () => {
 


### PR DESCRIPTION
- I've split the SearchableSelect into two components, one that keeps the state and one stateless component that only renders itself according to props. It should make it a little easier to reason about the behavior (and in the future test)

- Renamed `onSearch` event to the more specific `onInputChange`
- Renamed the `renderValue` function prop to `valueToString`, which more closely describes what it does.

- The Items array is treated as a black box, and no longer need to have a title (not sure if that actually was a requirement before either), it can now be anything from a string, to complex objects.
- Renamed boolean props to be prefixed with `is`/`has`, e.g. `open` => `isOpen`

This should also fix an issue with input value not being in sync with the actual chosen value, etc.