### PR TITLE
Clear DefaultButton timeout on componentWillUnmount

### DIFF
--- a/src/buttons/DefaultButton.js
+++ b/src/buttons/DefaultButton.js
@@ -40,11 +40,16 @@ export default class DefaultButton extends React.Component {
       recentlyHovered: true
     })
     this.props.onClick(event)
+    clearTimeout(this.timeOut)
     this.timeOut = setTimeout(() => {
       this.setState({
         recentlyHovered: true
       })
     }, 300)
+  }
+
+  componentWillUnmount() {
+    clearTimeout(this.timeOut)
   }
 
   render() {


### PR DESCRIPTION
Components that use setTimeout to update state should always clear the timeout on `componentDidMount`